### PR TITLE
Eta 84: Replacing deprecated Anchore Scanner with Trivy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -241,7 +241,7 @@ steps:
         cpu: 1000
         memory: 1024Mi
       environment:
-      IMAGE_NAME: aeta:${DRONE_COMMIT_SHA}
+      IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
       when:
       event:
       - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -382,7 +382,7 @@ steps:
       cron: tear_down_pr_envs
       event: cron
 
-  # CRON job steps that runs security scans using Snyk & Anchore
+  # CRON job steps that runs security scans using Snyk
   - name: cron_clone_repos
     image: alpine/git
     environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -241,16 +241,21 @@ steps:
         cpu: 1000
         memory: 1024Mi
       environment:
-      IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
+        IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
+        IGNORE_UNFIXED: "true"
       when:
-      event:
-      - pull_request
-      - push
-      - tag
+        event:
+        - pull_request
+        - push
+        - tag
 
   services:
     - name: docker
       image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+      resources:
+        limits:
+          cpu: 1000
+          memory: 1024Mi
 
   volumes:
     - name: dockersock

--- a/.drone.yml
+++ b/.drone.yml
@@ -116,6 +116,23 @@ steps:
       branch: master
       event: [push, pull_request]
 
+  - name: pull image for scan
+    pull: Always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+    resources:
+      limits:
+        cpu: 100
+        memory: 256Mi
+    commands:
+    # wait for docker service to be up before running docker build
+    - /usr/local/bin/wait
+    - docker pull acp-example-app:${DRONE_COMMIT_SHA}
+    when:
+      event:
+      - pull_request
+      - push
+      - tag
+  
   - name: image_to_quay
     pull: if-not-exists
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
@@ -200,7 +217,7 @@ steps:
       branch: master
       event: pull_request
 
-  # Snyk & Anchore security scans which run after branch deployment to prevent blocking of PR UAT tests
+  # Snyk & Trivy security scans which run after branch deployment to prevent blocking of PR UAT tests
   - name: snyk_scan
     pull: if-not-exists
     image: node:18
@@ -216,17 +233,20 @@ steps:
           - feature/*
       event: pull_request
 
-  - name: anchore_scan
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-    pull: always
-    environment:
-      IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
-      LOCAL_IMAGE: true
-      TOLERATE: medium
-      WHITELIST_FILE: hof-services-config/ETA/anchore-cve-exceptions.txt
-    when:
-      branch: master
-      event: pull_request
+  - name: scan-image
+    pull: Always
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
+    resources:
+      limits:
+        cpu: 1000
+        memory: 1024Mi
+      environment:
+      IMAGE_NAME: aeta:${DRONE_COMMIT_SHA}
+      when:
+      event:
+      - pull_request
+      - push
+      - tag
 
   # Deploy to master UAT environment
   - name: deploy_to_uat
@@ -401,17 +421,6 @@ steps:
       cron: security_scans
       event: cron
 
-  - name: cron_anchore_scan
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-    pull: always
-    environment:
-      IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
-      LOCAL_IMAGE: true
-      TOLERATE: medium
-      WHITELIST_FILE: hof-services-config/ETA/anchore-cve-exceptions.txt
-    when:
-      cron: security_scans
-      event: cron
 
   # Slack notification upon a CRON job fail
   - name: cron_notify_slack_tear_down_pr_envs
@@ -452,12 +461,6 @@ services:
   - name: docker
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
 
-  # Anchore scanning needs background service to run
-  - name: anchore-submission-server
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
-    pull: always
-    commands:
-      - /run.sh server
 
   # Redis session setup in background so integration tests can run
   - name: session

--- a/.drone.yml
+++ b/.drone.yml
@@ -248,6 +248,14 @@ steps:
       - push
       - tag
 
+  services:
+    - name: docker
+      image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+
+  volumes:
+    - name: dockersock
+      temp: {}
+
   # Deploy to master UAT environment
   - name: deploy_to_uat
     pull: if-not-exists

--- a/.drone.yml
+++ b/.drone.yml
@@ -395,7 +395,7 @@ steps:
       cron: tear_down_pr_envs
       event: cron
 
-  # CRON job steps that runs security scans using Snyk
+  # CRON job steps that runs security scans using Snyk & Anchore
   - name: cron_clone_repos
     image: alpine/git
     environment:
@@ -430,6 +430,18 @@ steps:
       - yarn install --frozen-lockfile
       - yarn run postinstall
       - yarn run test:snyk
+    when:
+      cron: security_scans
+      event: cron
+
+  - name: cron_anchore_scan
+    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/anchore-submission:latest
+    pull: always
+    environment:
+      IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
+      LOCAL_IMAGE: true
+      TOLERATE: medium
+      WHITELIST_FILE: hof-services-config/ETA/anchore-cve-exceptions.txt
     when:
       cron: security_scans
       event: cron


### PR DESCRIPTION
Added Trivy Scanner steps to Drone CI pipeline for scanning docker images 