### PR TITLE
ETA-112: Wording fix for eligibility screen

### DIFF
--- a/apps/eta/views/eligibility.html
+++ b/apps/eta/views/eligibility.html
@@ -1,6 +1,6 @@
 {{<partials-page}}
   {{$page-content}}
-    <p><a href="https://www.gov.uk/check-uk-visa">Check if you add an ETA.</a> This service will tell you what you need to come to the UK.</p>
+    <p><a href="https://www.gov.uk/check-uk-visa">Check if you need an ETA.</a> This service will tell you what you need to come to the UK.</p>
     <p>Or, you can <a href="https://www.gov.uk/guidance/apply-for-an-electronic-travel-authorisation-eta">read the ETA guidance</a> about who can apply for an ETA and who does not need one.</p>
     <h2 class="govuk-heading-m"> If you are a resident of Ireland </h2>
     <p>Some people who live in Ireland do not need an ETA to come to the UK. There is specific <a href="https://www.gov.uk/guidance/electronic-travel-authorisation-eta-residents-of-ireland">ETA guidance for residents of Ireland</a> available.</p>


### PR DESCRIPTION
## What
- Fixed a wording issue on the eligibility page [ETA-112](https://collaboration.homeoffice.gov.uk/jira/browse/ETA-112)

## Why
- There was a wording mistake on the page

## How
- Change text in eligibility.html

## Testing
- Tests passing locally