### PR TITLE
HOFF-438: Add CVE exceptions path to Trivy

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -158,9 +158,10 @@ steps:
         memory: 1024Mi
     environment:
       IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
-      TOLERATE: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+      TOLERATE: MEDIUM,HIGH,CRITICAL
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/Electronic_Travel_Authorisation/trivy-cve-exceptions.txt
     when:
       event:
       - pull_request
@@ -431,8 +432,11 @@ steps:
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
-        IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
-        IGNORE_UNFIXED: true
+      IMAGE_NAME: eta:${DRONE_COMMIT_SHA}
+      SEVERITY: MEDIUM,HIGH,CRITICAL
+      FAIL_ON_DETECTION: false
+      IGNORE_UNFIXED: true
+      ALLOW_CVE_LIST_FILE: hof-services-config/Electronic_Travel_Authorisation/trivy-cve-exceptions.txt
     when:
       cron: security_scans
       event: cron

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:lts-alpine@sha256:19eaf41f3b8c2ac2f609ac8103f9246a6a6d46716cdbe49103fd
 
 USER root
 
-# Update packages as a result of Anchore security vulnerability checks
 RUN apk update && \
     apk add --upgrade gnutls binutils nodejs npm apk-tools libjpeg-turbo libcurl libx11 libxml2
 


### PR DESCRIPTION
What?
 I've added CVE path for Trivy Scanner to Pipeline. This is the first service I added trivy. At the time we haven't decided about CVE exceptions path file and Severity. Later as ETA is going for LIVE I haven't got chance to update. see ticket
[https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-438](url)

Why?
Trivy will let you scan images, file systems and repositories for any vulnerabilities and issues. It will detect CVEs of OS packages, applications susceptibilities, and exposures of IaC in Terraform files, Kubernetes and Docker. Drawback of Anchore Scanner is it’s significantly slower, the process of using it is more cumbersome, the output is less friendly and most importantly, it scans fewer CVEs. 

How?
Removed Anchore cve exception file and added trivy cve exception file in hof-services-config repo from ETA configs. Removed Anchore Scanner steps from pipeline and added trivy scanner steps with cron scanner. Our Acceptance criteria is to list the Medium to Critical vulnerabilities.

Testing?
We can test it by raising pull request to Master branch. Drone Pipeline should run through the steps and should list the Medium to Critical Vulnerabilties and should progress to next steps of deployment to branch
[https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/eta/287/1/7](url)

Screenshots This screenshot is from Drone CI console
![image](https://github.com/UKHomeOffice/eta/assets/146218064/86c8f163-112e-444c-8b31-416ca7cacb66)
