### PR TITLE
HOFF-661: Deindex ETA webform

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -22,4 +22,12 @@ ignore:
      - '*':
         reason: Need to replace nodeemailer in HOF
         expires: '2024-11-01T17:02:21.865Z'
+  SNYK-JS-FOLLOWREDIRECTS-6444610:
+    - '*':
+        reason: Need to upgrade package in HOF
+        expires: '2024-06-22T17:02:21.865Z'
+  SNYK-JS-NODEMAILER-6219989:
+    - '*':
+        reason: Need to upgrade nodemailer in HOF
+        expires: '2024-06-22T17:02:21.865Z'
 patch: {}

--- a/apps/eta/views/layout.html
+++ b/apps/eta/views/layout.html
@@ -1,0 +1,61 @@
+{{<govuk-template}}
+  {{$head}}
+    {{> partials-head}}
+  {{/head}}
+  {{$pageTitle}}
+    {{#errorlist.length}}{{#t}}errorlist.prefix{{/t}}{{/errorlist.length}}{{$header}}{{/header}} &ndash; GOV.UK
+  {{/pageTitle}}
+  {{$bodyStart}}
+    <a href="#{{#skipToMain}}{{skipToMain}}{{/skipToMain}}{{^skipToMain}}main-content{{/skipToMain}}" class="govuk-skip-link" id="skip-to-main">Skip to main content</a>
+  {{/bodyStart}}
+  {{$headerClass}}govuk-header{{/headerClass}}
+  {{$insideHeader}}{{/insideHeader}}
+  {{$main}}
+	  <div class="govuk-width-container ">
+		{{#feedbackUrl}}
+			<div class="govuk-phase-banner">
+				<p class="govuk-phase-banner__content">
+				<strong class="govuk-tag govuk-phase-banner__content__tag">{{#t}}journey.phase{{/t}}</strong>
+				<span  class="govuk-phase-banner__text">This is a new service – your <a href="{{feedbackUrl}}{{^feedbackUrl}}https://eforms.homeoffice.gov.uk/outreach/feedback.ofml{{/feedbackUrl}}" class="govuk-link" id="feedback-link" target="_blank">feedback</a> will help us to improve it.</span>
+				</p>
+			</div>
+		{{/feedbackUrl}}      
+      <span id="step">
+        {{> partials-back}} <span>{{$step}}{{/step}}</span>
+      </span>
+	  <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+		  <div class="govuk-grid-row" id="gov-grid-row-content">
+			{{> partials-maincontent-left}}
+		  </div>
+	  </main>
+      {{> partials-continue}}
+      <script type="text/javascript" src="{{assetPath}}/js/bundle.js"></script>
+	  </div>
+  {{/main}}
+  {{$cookieMessage}}
+    {{#gaTagId}}
+      {{> partials-cookie-banner}}
+    {{/gaTagId}}
+    {{^gaTagId}}
+      <p class="no-ga-tag">
+        {{#t}}cookies.banner.message{{/t}}
+        <a href="/cookies">{{#t}}cookies.banner.link{{/t}}</a>
+      </p>
+    {{/gaTagId}}
+  {{/cookieMessage}}
+  {{$footerSupportLinks}}
+    <ul class="govuk-footer__inline-list">
+      {{#footerSupportLinks}}
+        <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{path}}">{{#t}}{{property}}{{/t}}</a></li>
+      {{/footerSupportLinks}}
+      {{^footerSupportLinks}}
+        <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="/cookies">{{#t}}base.cookies{{/t}}</a></li>
+        <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/terms-and-conditions">{{#t}}base.terms{{/t}}</a></li>
+        <li class="govuk-footer__inline-list-item"><a  class="govuk-footer__link" href="/accessibility">{{#t}}base.accessibility{{/t}}</a></li>
+      {{/footerSupportLinks}}
+    </ul>
+  {{/footerSupportLinks}}
+  {{$bodyEnd}}
+    {{> partials-gatag}}
+  {{/bodyEnd}}
+{{/govuk-template}}

--- a/apps/eta/views/partials/head.html
+++ b/apps/eta/views/partials/head.html
@@ -1,0 +1,26 @@
+{{#gtmTagId}}
+{{#cookiesAccepted}}
+<!-- Google Tag Manager Data Layer  -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  var dataLayer = window.dataLayer || [];
+  dataLayer.push(
+    {{{gtmConfig}}}
+  );
+</script>
+<!-- End Google Tag Manager Data Layer  -->
+
+<!-- Google Tag Manager -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{gtmTagId}}');
+</script>
+<!-- End Google Tag Manager -->
+{{/cookiesAccepted}}
+{{/gtmTagId}}
+
+<meta name="robots" content="noindex">
+<meta name="format-detection" content="telephone=no">
+<link rel="stylesheet" href="{{assetPath}}/css/app.css">


### PR DESCRIPTION
## What
De-index the ETA web form - [HOFF-661](https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-661)

## Why
So it is not returned in browser searches

## How
- Add /views/layout.html and /views/partials/head.html to include the 'robots' meta tag, with content of 'noindex'
- Add security vulnerabilities to .snyk file, to be addressed in the framework

## Testing
Tests passing locally