### PR TITLE
[ETA 133] Update the session ttl value to 30 minutes to match HOF timeout setting

### DIFF
--- a/hof.settings.json
+++ b/hof.settings.json
@@ -10,7 +10,7 @@
   "views": ["./apps/eta/views"],
   "session": {
     "name": "eta.hof.sid",
-    "ttl": 3600
+    "ttl": 1800
   },
   "getAccessibility": false
 }


### PR DESCRIPTION
## What?
- ETA-133: Following on from [PR 64](https://github.com/UKHomeOffice/eta/pull/64) where the session timeout behaviour was implemented, the session ttl has now been set to 1800s (30 minutes) to match the HoF default timeout setting. Link to ticket: [ETA-133](https://collaboration.homeoffice.gov.uk/jira/browse/ETA-133)
## Why?
- ETA-133: To comply with WCAG 2.2 accessibility requirements
## How?
In the hof.settings.json, the ttl value was set to 1800.
## Testing?
Test passing locally and on branch; manual testing
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
