### PR TITLE
HOFF-1245: Use latest Redis Docker image with fixed vulnerabilities

### DIFF
--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -31,8 +31,8 @@ spec:
     spec:
       containers:
         - name: redis
-          # redis:v5.0.6-1
-          image: quay.io/ukhomeofficedigital/redis@sha256:4499ea7306de776dab2ba8befd723a419fd311519d6f91f7821ed1a7c589da3b
+          # redis:v7.0.15
+          image: quay.io/ukhomeofficedigital/hof-docker-redis:7.0.15@sha256:cd4965fbb8aa6e4eba058985cc52f6a3ececdfa6d79ba44206f051f72a1f0611
           ports:
             - containerPort: 6379
           volumeMounts:


### PR DESCRIPTION
* Following changes have been made to the Redis image:
* Upgraded Redis from version 5.0.6 to 7.0.15 and tagged the image accordingly.
* Switched the base image from Fedora to Rocky Linux 9.3 to ensure compatibility with Trivy vulnerability scanning.

## What?
## Why?
## How?
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
