### PR TITLE
HOT-FIX-PROD-BUILD: Add dependency to deploy prod

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -348,6 +348,8 @@ steps:
     when:
       target: PROD
       event: promote
+    depends_on:
+      - clone_repos_prod
 
   # CRON job step that tears down our pull request UAT environments
   - name: cron_tear_down


### PR DESCRIPTION
## What?

* All the builds for hof services are working without dependency
* For ETA deploy to prod step is running ahead of clone repos. 
* Missing hof-services-config is failing the build.
* We added depends_on to wait for clone repos to execute before deploying to prod

## Why?

* Order of execution of Drone pipeline steps are incorrect hence we are seeing the build failure
* Now the deploy_to_prod step will wait for clone_repos to complete before it startsx
* deploy_to_prod steps requires files from hof-services-config to create configmaps and annotations


## How?

* Add Depends on to the step

## Testing?
Testing not required. retry the prod build once pushed to Master using the latest Push event build

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
