### PR TITLE
ETAWM-39: updating customer email statement

### DIFF
--- a/apps/eta/emails/customer.html
+++ b/apps/eta/emails/customer.html
@@ -12,7 +12,7 @@ We will reply within 3 working days (Monday-Friday). We will ask for more inform
 {{#table}}
 {{#value}}
   #{{{value}}}
-  You must apply for an ETA before you travel to the UK. You can travel to the UK while waiting for a decision.
+  You must apply for an ETA before you travel to the UK. You cannot travel to the UK until you have an ETA, visa or other immigration status.
   {{/value}}
 {{/table}}
 {{/data}}

--- a/test/_unit/emails/customer-email-template.spec.js
+++ b/test/_unit/emails/customer-email-template.spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const mustache = require('mustache');
+
+describe('Customer email template', () => {
+  const templatePath = path.resolve(__dirname, '../../../apps/eta/emails/customer.html');
+  const template = fs.readFileSync(templatePath, 'utf8');
+
+  it('renders customer details and ETA warning when data row has a value', () => {
+    const output = mustache.render(template, {
+      name: 'Alex Example',
+      'your-question': 'When will I get my decision?',
+      data: [
+        {
+          table: [
+            {
+              value: 'If you need to travel soon'
+            }
+          ]
+        }
+      ]
+    });
+
+    assert.ok(output.includes('Dear Alex Example'));
+    assert.ok(output.includes('When will I get my decision?'));
+    assert.ok(output.includes('If you need to travel soon'));
+    assert.ok(output.includes('You must apply for an ETA before you travel to the UK.'));
+  });
+
+  it('does not render ETA warning block when value is empty', () => {
+    const output = mustache.render(template, {
+      name: 'Alex Example',
+      'your-question': 'When will I get my decision?',
+      data: [
+        {
+          table: [
+            {
+              value: ''
+            }
+          ]
+        }
+      ]
+    });
+
+    assert.ok(!output.includes('You must apply for an ETA before you travel to the UK.'));
+  });
+});

--- a/test/_unit/sections/summary-data-sections.spec.js
+++ b/test/_unit/sections/summary-data-sections.spec.js
@@ -2,7 +2,7 @@ const sections = require('../../../apps/eta/sections/summary-data-sections.js');
 const pages = require('../../../apps/eta/translations/src/en/pages.json');
 
 describe('Apply Summary Data Sections', () => {
-  describe.only('Sections and Pages', () => {
+  describe('Sections and Pages', () => {
     it('should have sections and page translations that correlate', () => {
       const sectionsKeys = Object.keys(sections).sort();
       const pagesSectionsKeys = Object.keys(pages.confirm.sections).sort();


### PR DESCRIPTION
## What?

This PR updates the customer.html email template to change the wording.

## Why?

Current wording
Under the heading “If you need to travel soon”, the service currently states:

You must apply for an ETA before you travel to the UK. You can travel to the UK while waiting for a decision.

However it should be advising on the following

If you need to travel soon

You must apply for an ETA before you travel to the UK. You cannot travel to the UK until you have an ETA, visa or other immigration status.

## How?

Updated wording

## Testing?

Test added

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [X] I have written tests (if relevant)
- [X] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [X] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [X] Ensure drone builds are green especially tests
- [X] I will squash the commits before merging
