### PR TITLE
Feature/eta 186

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ unit_tests: &unit_tests
 
 sonar_scanner: &sonar_scanner
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/sonar-scanner-nodejs:latest
+  image: quay.io/ukhomeofficedigital/sonar-scanner:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,7 +40,7 @@ unit_tests: &unit_tests
     - yarn run test:unit
 
 sonar_scanner: &sonar_scanner
-  pull: if-not-exists
+  pull: always
   image: quay.io/ukhomeofficedigital/sonar-scanner:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties

--- a/.drone.yml
+++ b/.drone.yml
@@ -139,7 +139,7 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
+      IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
       SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
       SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree
       FAIL_ON_DETECTION: false
@@ -422,7 +422,7 @@ steps:
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest
     pull: always
     environment:
-        IMAGE_NAME: node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
+        IMAGE_NAME: quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
         FAIL_ON_DETECTION: true
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
+FROM quay.io/ukhomeofficedigital/hof-nodejs:20.20.2-alpine3.23@sha256:bcd17b68a0f1910f1670b07f6a47d1e2c28291bafc219807c494dc62b57ea25e
 
 USER root
 

--- a/apps/eta/emails/customer.html
+++ b/apps/eta/emails/customer.html
@@ -12,7 +12,7 @@ We will reply within 3 working days (Monday-Friday). We will ask for more inform
 {{#table}}
 {{#value}}
   #{{{value}}}
-  You must apply for an ETA before you travel to the UK. You can travel to the UK while waiting for a decision.
+  You must apply for an ETA before you travel to the UK. You cannot travel to the UK until you have an ETA, visa or other immigration status.
   {{/value}}
 {{/table}}
 {{/data}}

--- a/apps/eta/views/start.html
+++ b/apps/eta/views/start.html
@@ -10,7 +10,7 @@
     <p>If you are waiting for a decision on an ETA application, do not contact us until 3 working days (Monday-Friday) after you applied.</p>
 
     <p><strong>If you need to travel soon</strong></p>
-    <p>You must apply for an ETA before you travel to the UK. You can travel to the UK while waiting for a decision.</p>
+    <p>You must apply for an ETA before you travel to the UK. You cannot travel to the UK until you have an ETA, visa or other immigration status.</p>
 
     <h2>What you'll need</h2>
     <p>You will need:</p>

--- a/test/_unit/emails/customer-email-template.spec.js
+++ b/test/_unit/emails/customer-email-template.spec.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const mustache = require('mustache');
+
+describe('Customer email template', () => {
+  const templatePath = path.resolve(__dirname, '../../../apps/eta/emails/customer.html');
+  const template = fs.readFileSync(templatePath, 'utf8');
+
+  it('renders customer details and ETA warning when data row has a value', () => {
+    const output = mustache.render(template, {
+      name: 'Alex Example',
+      'your-question': 'When will I get my decision?',
+      data: [
+        {
+          table: [
+            {
+              value: 'If you need to travel soon'
+            }
+          ]
+        }
+      ]
+    });
+
+    assert.ok(output.includes('Dear Alex Example'));
+    assert.ok(output.includes('When will I get my decision?'));
+    assert.ok(output.includes('If you need to travel soon'));
+    assert.ok(output.includes('You must apply for an ETA before you travel to the UK.'));
+  });
+
+  it('does not render ETA warning block when value is empty', () => {
+    const output = mustache.render(template, {
+      name: 'Alex Example',
+      'your-question': 'When will I get my decision?',
+      data: [
+        {
+          table: [
+            {
+              value: ''
+            }
+          ]
+        }
+      ]
+    });
+
+    assert.ok(!output.includes('You must apply for an ETA before you travel to the UK.'));
+  });
+});

--- a/test/_unit/sections/summary-data-sections.spec.js
+++ b/test/_unit/sections/summary-data-sections.spec.js
@@ -2,7 +2,7 @@ const sections = require('../../../apps/eta/sections/summary-data-sections.js');
 const pages = require('../../../apps/eta/translations/src/en/pages.json');
 
 describe('Apply Summary Data Sections', () => {
-  describe.only('Sections and Pages', () => {
+  describe('Sections and Pages', () => {
     it('should have sections and page translations that correlate', () => {
       const sectionsKeys = Object.keys(sections).sort();
       const pagesSectionsKeys = Object.keys(pages.confirm.sections).sort();


### PR DESCRIPTION
## What?

This PR updates the customer.html email template to change the wording.

## Why?

Current wording
Under the heading “If you need to travel soon”, the service currently states:

You must apply for an ETA before you travel to the UK. You can travel to the UK while waiting for a decision.

However it should be advising on the following

If you need to travel soon

You must apply for an ETA before you travel to the UK. You cannot travel to the UK until you have an ETA, visa or other immigration status.

## How?

Updated wording

## Testing?

Test added

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [X] I have written tests (if relevant)
- [X] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [X] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [X] Ensure drone builds are green especially tests
- [X] I will squash the commits before merging
