### PR TITLE
ETA-184 [FIx]: Fix Cookie Banner

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,0 +1,1 @@
+require('hof/frontend/themes/gov-uk/client-js');


### PR DESCRIPTION
## What?
Fix for issue introduced in 'ETA-184: Update dependencies and node image'
(https://github.com/UKHomeOffice/eta/pull/90)

## Why?
Fix issue with cookie banner not showing after changes made in PR #90 

## How?
- Adds back reference to gov-uk client-js theme needed for rendering cookie banner

## Testing?
- Manually tested
- Code linted

## Screenshots (optional)
<img width="944" height="561" alt="Screenshot 2026-07-21 at 17 00 17" src="https://github.com/user-attachments/assets/8af89577-e1ad-4aa1-81b5-df756bf130d7" />

## Check list
- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
